### PR TITLE
step5 釣り銭と売り上げ管理の実装

### DIFF
--- a/src/usecases/__tests__/vendingMachine.spec.ts
+++ b/src/usecases/__tests__/vendingMachine.spec.ts
@@ -90,8 +90,8 @@ describe('vendingMachine', () => {
   it('コーラを購入する', () => {
     vm.post(MoneyType.FIVE_HUNDRED);
     expect(vm.balance).toBe(500);
-    vm.buying(JuiceType.COKE);
-    expect(vm.balance).toBe(380);
+    expect(vm.buying(JuiceType.COKE)).toBe(380);
+    expect(vm.balance).toBe(0);
     expect(vm.stocksInfo()).toEqual([
       'name:コーラ price:￥120 stock:4本',
       'name:レッドブル price:￥200 stock:5本',

--- a/src/usecases/vendingMachine.ts
+++ b/src/usecases/vendingMachine.ts
@@ -90,6 +90,6 @@ export class VendingMachine {
       this.balance -= selectedJuice.price;
       this.earning += selectedJuice.price;
     }
-    return 0;
+    return this.refund();
   }
 }


### PR DESCRIPTION
## 概要
- ジュース値段以上の投入金額が投入されている条件下で購入操作を行うと、釣り銭（投入金額とジュース値段の差分）を出力する。
  - ジュースと投入金額が同じ場合、つまり、釣り銭0円の場合も、釣り銭0円と出力する。
 
